### PR TITLE
Handle MSS option the same way as upstream kernel module.

### DIFF
--- a/ipt_RAWCOOKIE.c
+++ b/ipt_RAWCOOKIE.c
@@ -327,7 +327,7 @@ rawcookie_init_timestamp_cookie(const struct xt_rawcookie_info *info,
 {
 	opts->tsecr = opts->tsval;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
-	opts->tsval = tcp_jiffies32 & ~0x3f;
+	opts->tsval = tcp_time_stamp_raw() & ~0x3f;
 #else
 	opts->tsval = tcp_time_stamp & ~0x3f;
 #endif

--- a/ipt_RAWCOOKIE.c
+++ b/ipt_RAWCOOKIE.c
@@ -183,10 +183,8 @@ rawcookie_send_tcp(struct net *net,
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 	ip_local_out(net, nskb->sk, nskb);
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,25)
-	ip_local_out(nskb);
 #else
-#error "The module is not supported on this kernel. Use >= 2.6.25"
+	ip_local_out(nskb);
 #endif
 
 	return;
@@ -313,11 +311,9 @@ rawcookie_send_client_synack(struct net *net,
 		nskb->nfct = &nf_ct_untracked_get()->ct_general;
 		nskb->nfctinfo = IP_CT_NEW;
 		nf_conntrack_get(nskb->nfct);
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
+#else
 		/* backported from kernel 4.11 - centos7 */
 		nf_ct_set(nskb, NULL, IP_CT_UNTRACKED);
-#else
-#error "The module is not supported on this kernel. Use >= 3.10"
 #endif
 		rawcookie_send_tcp(net, skb, nskb, NULL,
 			IP_CT_ESTABLISHED_REPLY, niph, nth, tcp_hdr_size);


### PR DESCRIPTION
Hi, we have been asked by O2 to improve the MSS handling on newer kernel version. This was done independently from the bug report made by O2 that resulted in commit 4f58894. We have arrived at a different solution then the mentioned commit. We think that our solution more closely matches the behavior of the regular "non-raw" synproxy module in current version of the kernel regarding independent MSS in different TCP directions. The module has now been used in production for some time and we would like to merge the changes back to upstream.