### PR TITLE
Fix double free and resolve compatibility isse with newer version of xtables.

### DIFF
--- a/ipt_RAWCOOKIE.c
+++ b/ipt_RAWCOOKIE.c
@@ -204,7 +204,6 @@ rawcookie_send_tcp_raw(struct net *net,
 {
 
 	struct ethhdr *eth_h;  /* Ethernet header */
-	int ret;
 
 	nth->check = ~tcp_v4_check(tcp_hdr_size, niph->saddr, niph->daddr, 0);
 	nskb->ip_summed   = CHECKSUM_PARTIAL;
@@ -239,14 +238,8 @@ rawcookie_send_tcp_raw(struct net *net,
 
 	eth_h->h_proto = nskb->protocol;
 
-
-	ret = dev_queue_xmit(nskb);
-    if (ret != 0) {
-        pr_debug("xt_rawcookie2: dev_queue_xmit failed. errno=%d.\n", -ret);
-        kfree_skb(nskb);
-    }
-
-	return;
+	/* dev_queue_xmit always consumes the buffer, regardless of the return value. */
+	dev_queue_xmit(nskb);
 }
 
 

--- a/libxt_RAWCOOKIE.c
+++ b/libxt_RAWCOOKIE.c
@@ -11,6 +11,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#define XTABLES_INTERNAL 1
 #include <xtables.h>
 #include "xt_RAWCOOKIE.h"
 


### PR DESCRIPTION
Hi, we have experienced some system crashes when performing loadtests on combination of newer kernel and HW. We have identified an issue with a double free when using the --senddirect option when queuing the packet  for xmit fails.

Also, newer versions of xtables have hidden some internal definitions for plugins under an ifdef. This merge fixes that as well.